### PR TITLE
Added empty case displaying : now displaying relevant message.

### DIFF
--- a/classes/class.beaverlister.php
+++ b/classes/class.beaverlister.php
@@ -165,7 +165,12 @@ class BeaverLister {
 	        		}
 
 	        		foreach ($usedModules as $key => $modules) {
-	        			echo '<strong>' . $key . ':</strong><br/>' . implode(', ', array_unique( $modules ) ) . '<br/>';
+	        			if ( !empty( $key ) ) {
+	        				echo '<strong>' . $key . ':</strong><br/>' . implode(', ', array_unique( $modules ) ) . '<br/>';
+	        			}
+	        			else {
+	        				echo 'A <b>section</b> on this page has no Beaver Builder modules added yet.<br/>';	
+	        			}
 	        		}
 	        	}
 	        	break;


### PR DESCRIPTION
The semi-colon has been replaced with a default message if no modules are used on the page or section of the page.